### PR TITLE
feat: setup dashboard overview layout

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1,5 +1,103 @@
-import React from 'react';
+'use client';
 
-export default function page() {
-  return <div>page</div>;
+import { useState } from 'react';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import ExpenseSummary from '@/components/dashboard/expense-summary';
+import CurrentActivities from '@/components/dashboard/current-activities';
+import MyGroups from '@/app/dashboard/groups/page';
+import { EmptyGroups } from '@/components/dashboard/groups/empty-groups';
+import { toast } from 'sonner';
+
+export default function DashboardPage() {
+  const [activeTab, setActiveTab] = useState('overview');
+  const [groups, setGroups] = useState([]); // Assuming you fetch groups data here
+
+  return (
+    <main className="flex-1 p-6">
+      <div className="mb-6 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="text-3xl font-bold">Dashboard</h1>
+          <p className="text-muted-foreground">Welcome back, Alex</p>
+        </div>
+      </div>
+
+      <Tabs
+        defaultValue="overview"
+        value={activeTab}
+        onValueChange={setActiveTab}
+        className="space-y-4"
+      >
+        <TabsList>
+          <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="groups">My Groups</TabsTrigger>
+          <TabsTrigger value="activities">Current Activities</TabsTrigger>
+        </TabsList>
+        <TabsContent value="overview" className="space-y-4">
+          <ExpenseSummary />
+
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+            <Card>
+              <CardContent className="p-6">
+                <div className="flex flex-col gap-1">
+                  <h3 className="font-semibold">Invite friends</h3>
+                  <p className="text-sm text-muted-foreground">
+                    Add friends to start sharing expenses.
+                  </p>
+                  <Button
+                    variant="outline"
+                    className="mt-2"
+                    onClick={() => {
+                      toast('Invite sent');
+                    }}
+                  >
+                    Send Invites
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent className="p-6">
+                <div className="flex flex-col gap-1">
+                  <h3 className="font-semibold">Create a new group</h3>
+                  <p className="text-sm text-muted-foreground">
+                    Start a group to track all expenses.
+                  </p>
+                  <Link href="/groups/new">
+                    <Button variant="outline" className="mt-2 w-full">
+                      Create Group
+                    </Button>
+                  </Link>
+                </div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent className="p-6">
+                <div className="flex flex-col gap-1">
+                  <h3 className="font-semibold">Check expenses</h3>
+                  <p className="text-sm text-muted-foreground">
+                    Keep tabs on what everyone owes in your group.
+                  </p>
+                  <Link href="/expenses">
+                    <Button variant="outline" className="mt-2 w-full">
+                      Check Expenses
+                    </Button>
+                  </Link>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+          <CurrentActivities limit={5} />
+        </TabsContent>
+        <TabsContent value="groups" className="space-y-4">
+          {groups.length > 0 ? <MyGroups /> : <EmptyGroups />}
+        </TabsContent>
+        <TabsContent value="activities" className="space-y-4">
+          <CurrentActivities limit={20} />
+        </TabsContent>
+      </Tabs>
+    </main>
+  );
 }

--- a/frontend/components/dashboard/current-activities.tsx
+++ b/frontend/components/dashboard/current-activities.tsx
@@ -1,0 +1,140 @@
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+interface CurrentActivitiesProps {
+  limit?: number;
+}
+
+export default function CurrentActivities({ limit = 10 }: CurrentActivitiesProps) {
+  // This would come from an API in a real app
+  const activities = [
+    {
+      id: 1,
+      user: {
+        name: 'Taylor Smith',
+        avatar: '/placeholder.svg?height=40&width=40',
+        initials: 'TS',
+      },
+      action: 'added',
+      expense: {
+        name: 'Dinner at Seafood Palace',
+        amount: 145.75,
+        date: 'Just now',
+        group: 'Cancun Trip 2025',
+      },
+    },
+    {
+      id: 2,
+      user: {
+        name: 'Morgan Chen',
+        avatar: '/placeholder.svg?height=40&width=40',
+        initials: 'MC',
+      },
+      action: 'added',
+      expense: {
+        name: 'Airport Taxi',
+        amount: 58.5,
+        date: '2 hours ago',
+        group: 'Cancun Trip 2025',
+      },
+    },
+    {
+      id: 3,
+      user: {
+        name: 'Jordan Lee',
+        avatar: '/placeholder.svg?height=40&width=40',
+        initials: 'JL',
+      },
+      action: 'settled',
+      expense: {
+        name: 'Electricity Bill',
+        amount: 120.0,
+        date: 'Yesterday',
+        group: 'Apartment 304',
+      },
+    },
+    {
+      id: 4,
+      user: {
+        name: 'Riley Davis',
+        avatar: '/placeholder.svg?height=40&width=40',
+        initials: 'RD',
+      },
+      action: 'added',
+      expense: {
+        name: 'Groceries',
+        amount: 85.2,
+        date: '2 days ago',
+        group: 'Apartment 304',
+      },
+    },
+    {
+      id: 5,
+      user: {
+        name: 'Alex Johnson',
+        avatar: '/placeholder.svg?height=40&width=40',
+        initials: 'AJ',
+      },
+      action: 'added',
+      expense: {
+        name: 'Movie Tickets',
+        amount: 48.0,
+        date: '3 days ago',
+        group: 'Dinner Club',
+      },
+    },
+    {
+      id: 6,
+      user: {
+        name: 'Taylor Smith',
+        avatar: '/placeholder.svg?height=40&width=40',
+        initials: 'TS',
+      },
+      action: 'settled',
+      expense: {
+        name: 'Lunch',
+        amount: 32.5,
+        date: '4 days ago',
+        group: 'Office Lunch Group',
+      },
+    },
+  ].slice(0, limit);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Recent Activities</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          {activities.map((activity) => (
+            <div key={activity.id} className="flex items-center gap-4">
+              <Avatar className="h-9 w-9">
+                <AvatarImage src={activity.user.avatar} alt={activity.user.name} />
+                <AvatarFallback>{activity.user.initials}</AvatarFallback>
+              </Avatar>
+              <div className="flex-1 space-y-1">
+                <p className="text-sm font-medium leading-none">
+                  <span className="font-semibold">{activity.user.name}</span>{' '}
+                  {activity.action === 'added' ? 'added' : 'settled'}{' '}
+                  <span className="font-semibold">{activity.expense.name}</span>{' '}
+                  {activity.action === 'added'
+                    ? `($${activity.expense.amount.toFixed(2)})`
+                    : `($${activity.expense.amount.toFixed(2)})`}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {activity.expense.date} • {activity.expense.group}
+                </p>
+              </div>
+              <div
+                className={`font-medium ${activity.action === 'settled' ? 'text-green-500' : ''}`}
+              >
+                {activity.action === 'added' ? `$${activity.expense.amount.toFixed(2)}` : `Settled`}
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/components/dashboard/empty-state.tsx
+++ b/frontend/components/dashboard/empty-state.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import type React from 'react';
+
+import { Button } from '@/components/ui/button';
+import Link from 'next/link';
+
+interface EmptyStateProps {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  actionText?: string;
+  actionLink?: string;
+  actionOnClick?: () => void;
+  secondaryActionText?: string;
+  secondaryActionLink?: string;
+  secondaryActionOnClick?: () => void;
+}
+
+export function EmptyState({
+  icon,
+  title,
+  description,
+  actionText,
+  actionLink,
+  actionOnClick,
+  secondaryActionText,
+  secondaryActionLink,
+  secondaryActionOnClick,
+}: EmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center rounded-lg border border-dashed p-8 text-center">
+      <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
+        {icon}
+      </div>
+      <h3 className="mb-2 text-lg font-medium">{title}</h3>
+      <p className="mb-6 max-w-md text-sm text-muted-foreground">{description}</p>
+      <div className="flex flex-wrap items-center justify-center gap-3">
+        {actionText && (actionLink || actionOnClick) && (
+          <>
+            {actionLink ? (
+              <Link href={actionLink}>
+                <Button>{actionText}</Button>
+              </Link>
+            ) : (
+              <Button onClick={actionOnClick}>{actionText}</Button>
+            )}
+          </>
+        )}
+        {secondaryActionText && (secondaryActionLink || secondaryActionOnClick) && (
+          <>
+            {secondaryActionLink ? (
+              <Link href={secondaryActionLink}>
+                <Button variant="outline">{secondaryActionText}</Button>
+              </Link>
+            ) : (
+              <Button variant="outline" onClick={secondaryActionOnClick}>
+                {secondaryActionText}
+              </Button>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/dashboard/expense-summary.tsx
+++ b/frontend/components/dashboard/expense-summary.tsx
@@ -1,0 +1,104 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+import { BadgeDollarSign, TrendingDown, TrendingUp } from 'lucide-react';
+
+export default function ExpenseSummary() {
+  return (
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">Total Balance</CardTitle>
+          <BadgeDollarSign className="h-4 w-4 text-muted-foreground" />
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">$451.92</div>
+          <p className="text-xs text-muted-foreground">Net balance across all groups</p>
+          <div className="mt-4">
+            <div className="mb-1 flex items-center justify-between text-xs">
+              <span>Assets vs. Debts</span>
+              <span className="font-medium">75%</span>
+            </div>
+            <Progress value={75} className="h-2" />
+          </div>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">You Are Owed</CardTitle>
+          <TrendingUp className="h-4 w-4 text-green-500" />
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold text-green-500">$520.00</div>
+          <p className="text-xs text-muted-foreground">From 3 people across 2 groups</p>
+          <div className="mt-4 grid gap-1">
+            <div className="flex justify-between text-xs">
+              <span>Morgan Chen</span>
+              <span className="font-medium">$320.00</span>
+            </div>
+            <div className="flex justify-between text-xs">
+              <span>Jordan Lee</span>
+              <span className="font-medium">$120.00</span>
+            </div>
+            <div className="flex justify-between text-xs">
+              <span>Taylor Smith</span>
+              <span className="font-medium">$80.00</span>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">You Owe</CardTitle>
+          <TrendingDown className="h-4 w-4 text-red-500" />
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold text-red-500">$68.08</div>
+          <p className="text-xs text-muted-foreground">To 1 person in 1 group</p>
+          <div className="mt-4 grid gap-1">
+            <div className="flex justify-between text-xs">
+              <span>Riley Davis</span>
+              <span className="font-medium">$68.08</span>
+            </div>
+            <div className="flex justify-between text-xs text-transparent">
+              <span>Placeholder</span>
+              <span className="font-medium">$0.00</span>
+            </div>
+            <div className="flex justify-between text-xs text-transparent">
+              <span>Placeholder</span>
+              <span className="font-medium">$0.00</span>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">Recent Activity</CardTitle>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            className="h-4 w-4 text-muted-foreground"
+          >
+            <rect x="2" y="7" width="20" height="14" rx="2" ry="2" />
+            <path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16" />
+          </svg>
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">5 expenses</div>
+          <p className="text-xs text-muted-foreground">Added in the last 7 days</p>
+          <div className="mt-4">
+            <div className="mb-1 flex items-center justify-between text-xs">
+              <span>Groups Activity</span>
+              <span className="font-medium">3/4 active</span>
+            </div>
+            <Progress value={75} className="h-2" />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/components/dashboard/groups/empty-groups.tsx
+++ b/frontend/components/dashboard/groups/empty-groups.tsx
@@ -1,0 +1,16 @@
+import { Users } from 'lucide-react';
+import { EmptyState } from '../empty-state';
+
+export function EmptyGroups() {
+  return (
+    <EmptyState
+      icon={<Users className="h-6 w-6 text-primary" />}
+      title="No groups yet"
+      description="Create your first group to start sharing expenses with friends, roommates, or travel companions."
+      actionText="Create Group"
+      actionLink="/groups/new"
+      secondaryActionText="Join a Group"
+      secondaryActionOnClick={() => {}}
+    />
+  );
+}

--- a/frontend/components/dashboard/groups/groups-page-content.tsx
+++ b/frontend/components/dashboard/groups/groups-page-content.tsx
@@ -142,15 +142,15 @@ export default function GroupsPageContent({ groups }: groupsProps) {
                           group.youOwe > 0
                             ? 'text-red-500'
                             : group.youAreOwed > 0
-                            ? 'text-green-500'
-                            : '',
+                              ? 'text-green-500'
+                              : '',
                         )}
                       >
                         {group.youOwe > 0
                           ? `-$${group.youOwe.toFixed(2)}`
                           : group.youAreOwed > 0
-                          ? `+$${group.youAreOwed.toFixed(2)}`
-                          : '$0.00'}
+                            ? `+$${group.youAreOwed.toFixed(2)}`
+                            : '$0.00'}
                       </div>
                     </TableCell>
                     <TableCell className="text-right">

--- a/frontend/components/ui/progress.tsx
+++ b/frontend/components/ui/progress.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import * as React from 'react';
+import * as ProgressPrimitive from '@radix-ui/react-progress';
+
+import { cn } from '@/lib/utils';
+
+function Progress({
+  className,
+  value,
+  ...props
+}: React.ComponentProps<typeof ProgressPrimitive.Root>) {
+  return (
+    <ProgressPrimitive.Root
+      data-slot="progress"
+      className={cn('bg-primary/20 relative h-2 w-full overflow-hidden rounded-full', className)}
+      {...props}
+    >
+      <ProgressPrimitive.Indicator
+        data-slot="progress-indicator"
+        className="bg-primary h-full w-full flex-1 transition-all"
+        style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+      />
+    </ProgressPrimitive.Root>
+  );
+}
+
+export { Progress };

--- a/frontend/components/ui/table.tsx
+++ b/frontend/components/ui/table.tsx
@@ -1,116 +1,92 @@
-"use client"
+'use client';
 
-import * as React from "react"
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-function Table({ className, ...props }: React.ComponentProps<"table">) {
+function Table({ className, ...props }: React.ComponentProps<'table'>) {
   return (
-    <div
-      data-slot="table-container"
-      className="relative w-full overflow-x-auto"
-    >
+    <div data-slot="table-container" className="relative w-full overflow-x-auto">
       <table
         data-slot="table"
-        className={cn("w-full caption-bottom text-sm", className)}
+        className={cn('w-full caption-bottom text-sm', className)}
         {...props}
       />
     </div>
-  )
+  );
 }
 
-function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
-  return (
-    <thead
-      data-slot="table-header"
-      className={cn("[&_tr]:border-b", className)}
-      {...props}
-    />
-  )
+function TableHeader({ className, ...props }: React.ComponentProps<'thead'>) {
+  return <thead data-slot="table-header" className={cn('[&_tr]:border-b', className)} {...props} />;
 }
 
-function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+function TableBody({ className, ...props }: React.ComponentProps<'tbody'>) {
   return (
     <tbody
       data-slot="table-body"
-      className={cn("[&_tr:last-child]:border-0", className)}
+      className={cn('[&_tr:last-child]:border-0', className)}
       {...props}
     />
-  )
+  );
 }
 
-function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+function TableFooter({ className, ...props }: React.ComponentProps<'tfoot'>) {
   return (
     <tfoot
       data-slot="table-footer"
-      className={cn(
-        "bg-muted/50 border-t font-medium [&>tr]:last:border-b-0",
-        className
-      )}
+      className={cn('bg-muted/50 border-t font-medium [&>tr]:last:border-b-0', className)}
       {...props}
     />
-  )
+  );
 }
 
-function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+function TableRow({ className, ...props }: React.ComponentProps<'tr'>) {
   return (
     <tr
       data-slot="table-row"
       className={cn(
-        "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
-        className
+        'hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+function TableHead({ className, ...props }: React.ComponentProps<'th'>) {
   return (
     <th
       data-slot="table-head"
       className={cn(
-        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
-        className
+        'text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+function TableCell({ className, ...props }: React.ComponentProps<'td'>) {
   return (
     <td
       data-slot="table-cell"
       className={cn(
-        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
-        className
+        'p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-function TableCaption({
-  className,
-  ...props
-}: React.ComponentProps<"caption">) {
+function TableCaption({ className, ...props }: React.ComponentProps<'caption'>) {
   return (
     <caption
       data-slot="table-caption"
-      className={cn("text-muted-foreground mt-4 text-sm", className)}
+      className={cn('text-muted-foreground mt-4 text-sm', className)}
       {...props}
     />
-  )
+  );
 }
 
-export {
-  Table,
-  TableHeader,
-  TableBody,
-  TableFooter,
-  TableHead,
-  TableRow,
-  TableCell,
-  TableCaption,
-}
+export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption };

--- a/frontend/components/ui/textarea.tsx
+++ b/frontend/components/ui/textarea.tsx
@@ -1,18 +1,18 @@
-import * as React from "react"
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
   return (
     <textarea
       data-slot="textarea"
       className={cn(
-        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        className
+        'border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Textarea }
+export { Textarea };

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-dialog": "^1.1.6",
         "@radix-ui/react-dropdown-menu": "^2.1.6",
         "@radix-ui/react-label": "^2.1.2",
+        "@radix-ui/react-progress": "^1.1.4",
         "@radix-ui/react-slot": "^1.1.2",
         "@radix-ui/react-switch": "^1.1.4",
         "@radix-ui/react-tabs": "^1.1.4",
@@ -1352,6 +1353,101 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.4.tgz",
+      "integrity": "sha512-8rl9w7lJdcVPor47Dhws9mUHRHLE+8JEgyJRdNWCpGPa6HIlr3eh+Yn9gyx1CnCLbw5naHsI2gaO9dBWO50vzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.0.tgz",
+      "integrity": "sha512-/J/FhLdK0zVcILOwt5g+dH4KnkonCtkVJsa2G6JmvbbtZfBEI1gMsO3QMjseL4F/SwfAMt1Vc/0XKYKq+xJ1sw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.0.tgz",
+      "integrity": "sha512-ujc+V6r0HNDviYqIK3rW4ffgYiZ8g5DEHrGJVk4x7kTlLXRDILnKX9vAUYeIsLOoDpDJ0ujpqMkjH4w2ofuo6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-dropdown-menu": "^2.1.6",
     "@radix-ui/react-label": "^2.1.2",
+    "@radix-ui/react-progress": "^1.1.4",
     "@radix-ui/react-slot": "^1.1.2",
     "@radix-ui/react-switch": "^1.1.4",
     "@radix-ui/react-tabs": "^1.1.4",


### PR DESCRIPTION
This pull request includes the set up of  the dashboard overview layout. The key updates include:

Responsive Design: The groups table is now fully responsive, ensuring usability across mobile, tablet, and desktop devices.
Expenses breakdown: This shows the overview of the expenses made and the balances
Current activities Display: This shows the table of  current activities.


closes #39 